### PR TITLE
Move pinata ticket functions -> Front-End Restructure Branch

### DIFF
--- a/src/components/OpenQuestionView.vue
+++ b/src/components/OpenQuestionView.vue
@@ -75,7 +75,7 @@ import QuestionMark from '@/components/QuestionMark.vue';
 import useCopy from '@/composables/copy';
 import ContentTooltipRarity from '@/components/content/tooltip/ContentTooltipRarity.vue';
 import { INFT, PNFT} from '@/common/helpers/types';
-
+import {generateTicketDetailLink, readTicketName, readTicketStatus, readTicketType, readMintID, readUserID, readDatePinned} from '@/composables/pinata'
 export default defineComponent({
   props: {
     n: Object,
@@ -88,67 +88,29 @@ export default defineComponent({
     VueJsonPretty,
   },
 
+  // by referencing methods here, have access through Vue componet + for other needs
   methods: {
-    generateTicketDetailLink (ticket: PNFT) {
-      /* Input: Takes in a ticket (pinata NFT metadata)
-         Output: link to ticket detail page using mintID or undefined (some tickets may not have mintID)
-      */
-       const ticket_detail_url_prefix = "/ticketdetail/"
-       const attr_key = "mintId"
-       let attr = ticket.metadata.keyvalues.hasOwnProperty(attr_key) ? ticket.metadata.keyvalues[attr_key] : undefined
-       return typeof attr != 'undefined' ? ticket_detail_url_prefix + attr : undefined
-
+    generateTicketDetailLink: function(ticket: PNFT) {
+      return generateTicketDetailLink(ticket)
     },
-
-    readTicketName (ticket: PNFT) {
-      /* Input: Takes in a ticket (pinata NFT metadata)
-         Output: reads ticket name from metadata or undefined (some tickets may not have a name)
-      */
-       const attr_key = 'name'
-       let attr = ticket.metadata.hasOwnProperty(attr_key) ? ticket.metadata[attr_key] : undefined
-       return typeof attr != 'undefined' ? attr : "Attribute Not Set"
+    readTicketName: function(ticket: PNFT) {
+      return readTicketName(ticket)
     },
-
-    readTicketStatus (ticket: PNFT) {
-      /* Input: Takes in a ticket (pinata NFT metadata)
-         Output: reads ticket status from metadata or undefined
-      */
-       const attr_key = 'status'
-       let attr = ticket.metadata.keyvalues.hasOwnProperty(attr_key) ? ticket.metadata.keyvalues[attr_key] : undefined
-       return typeof attr != 'undefined' ? attr : "Attribute Not Set"
+    readTicketStatus: function(ticket: PNFT) {
+      return readTicketStatus(ticket)
     },
-    readTicketType (ticket: PNFT) {
-      /* Input: Takes in a ticket (pinata NFT metadata)
-         Output: reads ticket status from metadata or undefined
-      */
-       const attr_key = 'ticket_type'
-       let attr = ticket.metadata.keyvalues.hasOwnProperty(attr_key) ? ticket.metadata.keyvalues[attr_key] : undefined
-       return typeof attr != 'undefined' ? attr : "Attribute Not Set"
+    readMintID: function(ticket: PNFT) {
+      return readMintID(ticket)
     },
-    readMintID (ticket: PNFT) {
-      /* Input: Takes in a ticket (pinata NFT metadata)
-         Output: reads ticket mint ID from metadata or undefined
-      */
-       const attr_key = 'mintId'
-       let attr = ticket.metadata.keyvalues.hasOwnProperty(attr_key) ? ticket.metadata.keyvalues[attr_key] : undefined
-       return typeof attr != 'undefined' ? attr : "Attribute Not Set"
+    readUserID: function(ticket: PNFT) {
+      return readUserID(ticket)
     },
-    readUserID (ticket: PNFT) {
-      /* Input: Takes in a ticket (pinata NFT metadata)
-         Output: reads ticket user ID from metadata or undefined
-      */
-       const attr_key = 'user_id'
-       let attr = ticket.hasOwnProperty(attr_key) ? ticket[attr_key] : undefined
-       return typeof attr != 'undefined' ? attr : "Attribute Not Set"
+    readDatePinned: function(ticket: PNFT) {
+      return readDatePinned(ticket)
     },
-    readDatePinned (ticket: PNFT) {
-      /* Input: Takes in a ticket (pinata NFT metadata)
-         Output: reads ticket date pinned to pinata from metadata or undefined
-      */
-       const attr_key = 'date_pinned'
-       let attr = ticket.hasOwnProperty(attr_key) ? ticket[attr_key] : undefined
-       return typeof attr != 'undefined' ? attr : "Attribute Not Set"
-    },
+    readTicketType: function(ticket: PNFT){
+      return readTicketType(ticket)
+    }
   },
 
   setup() {
@@ -160,6 +122,7 @@ export default defineComponent({
       fullJSON.value = !fullJSON.value;
     };
 
+   
     // --------------------------------------- clipboard
     const { copyText, doCopyJSON } = useCopy();
 

--- a/src/components/OpenQuestionView.vue
+++ b/src/components/OpenQuestionView.vue
@@ -75,7 +75,7 @@ import QuestionMark from '@/components/QuestionMark.vue';
 import useCopy from '@/composables/copy';
 import ContentTooltipRarity from '@/components/content/tooltip/ContentTooltipRarity.vue';
 import { INFT, PNFT} from '@/common/helpers/types';
-import {generateTicketDetailLink, readTicketName, readTicketStatus, readTicketType, readMintID, readUserID, readDatePinned} from '@/composables/pinata'
+import * as pnftInteractions from '@/composables/pnftInteractions'
 export default defineComponent({
   props: {
     n: Object,
@@ -91,25 +91,25 @@ export default defineComponent({
   // by referencing methods here, have access through Vue componet + for other needs
   methods: {
     generateTicketDetailLink: function(ticket: PNFT) {
-      return generateTicketDetailLink(ticket)
+      return pnftInteractions.generateTicketDetailLink(ticket)
     },
     readTicketName: function(ticket: PNFT) {
-      return readTicketName(ticket)
+      return pnftInteractions.readTicketName(ticket)
     },
     readTicketStatus: function(ticket: PNFT) {
-      return readTicketStatus(ticket)
+      return pnftInteractions.readTicketStatus(ticket)
     },
     readMintID: function(ticket: PNFT) {
-      return readMintID(ticket)
+      return pnftInteractions.readMintID(ticket)
     },
     readUserID: function(ticket: PNFT) {
-      return readUserID(ticket)
+      return pnftInteractions.readUserID(ticket)
     },
     readDatePinned: function(ticket: PNFT) {
-      return readDatePinned(ticket)
+      return pnftInteractions.readDatePinned(ticket)
     },
     readTicketType: function(ticket: PNFT){
-      return readTicketType(ticket)
+      return pnftInteractions.readTicketType(ticket)
     }
   },
 

--- a/src/composables/pinata.ts
+++ b/src/composables/pinata.ts
@@ -10,6 +10,72 @@ import { PNFT } from '@/common/helpers/types';
 const apiKey = '7ed5a3f0849f19876a1e';
 const apiSecret = '3d79c1f0f2293450b9c949cacc293c22223eeb8a33b24124e2d750c86627cbc9';
 
+
+
+
+export function generateTicketDetailLink(ticket: PNFT) {
+  /* Input: Takes in a ticket (pinata NFT metadata)
+     Output: link to ticket detail page using mintID or undefined (some tickets may not have mintID)
+  */
+     const ticket_detail_url_prefix = "/ticketdetail/"
+     const attr_key = "mintId"
+     let attr = ticket.metadata.keyvalues.hasOwnProperty(attr_key) ? ticket.metadata.keyvalues[attr_key] : undefined
+     return typeof attr != 'undefined' ? ticket_detail_url_prefix + attr : undefined
+}
+
+
+
+
+export function readTicketName (ticket: PNFT) {
+  /* Input: Takes in a ticket (pinata NFT metadata)
+     Output: reads ticket name from metadata or undefined (some tickets may not have a name)
+  */
+   const attr_key = 'name'
+   let attr = ticket.metadata.hasOwnProperty(attr_key) ? ticket.metadata[attr_key] : undefined
+   return typeof attr != 'undefined' ? attr : "Attribute Not Set"
+};
+
+export function readTicketStatus (ticket: PNFT) {
+  /* Input: Takes in a ticket (pinata NFT metadata)
+     Output: reads ticket status from metadata or undefined
+  */
+   const attr_key = 'status'
+   let attr = ticket.metadata.keyvalues.hasOwnProperty(attr_key) ? ticket.metadata.keyvalues[attr_key] : undefined
+   return typeof attr != 'undefined' ? attr : "Attribute Not Set"
+};
+export function readTicketType (ticket: PNFT) {
+  /* Input: Takes in a ticket (pinata NFT metadata)
+     Output: reads ticket status from metadata or undefined
+  */
+   const attr_key = 'ticket_type'
+   let attr = ticket.metadata.keyvalues.hasOwnProperty(attr_key) ? ticket.metadata.keyvalues[attr_key] : undefined
+   return typeof attr != 'undefined' ? attr : "Attribute Not Set"
+};
+export function readMintID (ticket: PNFT) {
+  /* Input: Takes in a ticket (pinata NFT metadata)
+     Output: reads ticket mint ID from metadata or undefined
+  */
+   const attr_key = 'mintId'
+   let attr = ticket.metadata.keyvalues.hasOwnProperty(attr_key) ? ticket.metadata.keyvalues[attr_key] : undefined
+   return typeof attr != 'undefined' ? attr : "Attribute Not Set"
+};
+export function readUserID (ticket: PNFT) {
+  /* Input: Takes in a ticket (pinata NFT metadata)
+     Output: reads ticket user ID from metadata or undefined
+  */
+   const attr_key = 'user_id'
+   let attr = ticket.hasOwnProperty(attr_key) ? ticket[attr_key] : undefined
+   return typeof attr != 'undefined' ? attr : "Attribute Not Set"
+};
+export function readDatePinned (ticket: PNFT) {
+  /* Input: Takes in a ticket (pinata NFT metadata)
+     Output: reads ticket date pinned to pinata from metadata or undefined
+  */
+   const attr_key = 'date_pinned'
+   let attr = ticket.hasOwnProperty(attr_key) ? ticket[attr_key] : undefined
+   return typeof attr != 'undefined' ? attr : "Attribute Not Set"
+}; 
+
 export default function usePinata() {
   const pinata = pinataSDK(apiKey, apiSecret);
 
@@ -198,6 +264,9 @@ export default function usePinata() {
       console.log(err);
     });
   };
+
+
+
 
   return {
     uploadImg,

--- a/src/composables/pinata.ts
+++ b/src/composables/pinata.ts
@@ -9,72 +9,7 @@ import { PNFT } from '@/common/helpers/types';
 //  I'm hoping it won't be abused - if it does, just put in your own and run locally or let me know (twitter @_ilmoi)
 const apiKey = '7ed5a3f0849f19876a1e';
 const apiSecret = '3d79c1f0f2293450b9c949cacc293c22223eeb8a33b24124e2d750c86627cbc9';
-
-
-
-
-export function generateTicketDetailLink(ticket: PNFT) {
-  /* Input: Takes in a ticket (pinata NFT metadata)
-     Output: link to ticket detail page using mintID or undefined (some tickets may not have mintID)
-  */
-     const ticket_detail_url_prefix = "/ticketdetail/"
-     const attr_key = "mintId"
-     let attr = ticket.metadata.keyvalues.hasOwnProperty(attr_key) ? ticket.metadata.keyvalues[attr_key] : undefined
-     return typeof attr != 'undefined' ? ticket_detail_url_prefix + attr : undefined
-}
-
-
-
-
-export function readTicketName (ticket: PNFT) {
-  /* Input: Takes in a ticket (pinata NFT metadata)
-     Output: reads ticket name from metadata or undefined (some tickets may not have a name)
-  */
-   const attr_key = 'name'
-   let attr = ticket.metadata.hasOwnProperty(attr_key) ? ticket.metadata[attr_key] : undefined
-   return typeof attr != 'undefined' ? attr : "Attribute Not Set"
-};
-
-export function readTicketStatus (ticket: PNFT) {
-  /* Input: Takes in a ticket (pinata NFT metadata)
-     Output: reads ticket status from metadata or undefined
-  */
-   const attr_key = 'status'
-   let attr = ticket.metadata.keyvalues.hasOwnProperty(attr_key) ? ticket.metadata.keyvalues[attr_key] : undefined
-   return typeof attr != 'undefined' ? attr : "Attribute Not Set"
-};
-export function readTicketType (ticket: PNFT) {
-  /* Input: Takes in a ticket (pinata NFT metadata)
-     Output: reads ticket status from metadata or undefined
-  */
-   const attr_key = 'ticket_type'
-   let attr = ticket.metadata.keyvalues.hasOwnProperty(attr_key) ? ticket.metadata.keyvalues[attr_key] : undefined
-   return typeof attr != 'undefined' ? attr : "Attribute Not Set"
-};
-export function readMintID (ticket: PNFT) {
-  /* Input: Takes in a ticket (pinata NFT metadata)
-     Output: reads ticket mint ID from metadata or undefined
-  */
-   const attr_key = 'mintId'
-   let attr = ticket.metadata.keyvalues.hasOwnProperty(attr_key) ? ticket.metadata.keyvalues[attr_key] : undefined
-   return typeof attr != 'undefined' ? attr : "Attribute Not Set"
-};
-export function readUserID (ticket: PNFT) {
-  /* Input: Takes in a ticket (pinata NFT metadata)
-     Output: reads ticket user ID from metadata or undefined
-  */
-   const attr_key = 'user_id'
-   let attr = ticket.hasOwnProperty(attr_key) ? ticket[attr_key] : undefined
-   return typeof attr != 'undefined' ? attr : "Attribute Not Set"
-};
-export function readDatePinned (ticket: PNFT) {
-  /* Input: Takes in a ticket (pinata NFT metadata)
-     Output: reads ticket date pinned to pinata from metadata or undefined
-  */
-   const attr_key = 'date_pinned'
-   let attr = ticket.hasOwnProperty(attr_key) ? ticket[attr_key] : undefined
-   return typeof attr != 'undefined' ? attr : "Attribute Not Set"
-}; 
+ 
 
 export default function usePinata() {
   const pinata = pinataSDK(apiKey, apiSecret);

--- a/src/composables/pnftInteractions.ts
+++ b/src/composables/pnftInteractions.ts
@@ -1,0 +1,62 @@
+import { PNFT } from '@/common/helpers/types';
+
+export function generateTicketDetailLink(ticket: PNFT) {
+    /* Input: Takes in a ticket (pinata NFT metadata)
+       Output: link to ticket detail page using mintID or undefined (some tickets may not have mintID)
+    */
+       const ticket_detail_url_prefix = "/ticketdetail/"
+       const attr_key = "mintId"
+       let attr = ticket.metadata.keyvalues.hasOwnProperty(attr_key) ? ticket.metadata.keyvalues[attr_key] : undefined
+       return typeof attr != 'undefined' ? ticket_detail_url_prefix + attr : undefined
+  }
+  
+
+  export function readTicketName (ticket: PNFT) {
+    /* Input: Takes in a ticket (pinata NFT metadata)
+       Output: reads ticket name from metadata or undefined (some tickets may not have a name)
+    */
+     const attr_key = 'name'
+     let attr = ticket.metadata.hasOwnProperty(attr_key) ? ticket.metadata[attr_key] : undefined
+     return typeof attr != 'undefined' ? attr : "Attribute Not Set"
+  };
+  
+  export function readTicketStatus (ticket: PNFT) {
+    /* Input: Takes in a ticket (pinata NFT metadata)
+       Output: reads ticket status from metadata or undefined
+    */
+     const attr_key = 'status'
+     let attr = ticket.metadata.keyvalues.hasOwnProperty(attr_key) ? ticket.metadata.keyvalues[attr_key] : undefined
+     return typeof attr != 'undefined' ? attr : "Attribute Not Set"
+  };
+  export function readTicketType (ticket: PNFT) {
+    /* Input: Takes in a ticket (pinata NFT metadata)
+       Output: reads ticket status from metadata or undefined
+    */
+     const attr_key = 'ticket_type'
+     let attr = ticket.metadata.keyvalues.hasOwnProperty(attr_key) ? ticket.metadata.keyvalues[attr_key] : undefined
+     return typeof attr != 'undefined' ? attr : "Attribute Not Set"
+  };
+  export function readMintID (ticket: PNFT) {
+    /* Input: Takes in a ticket (pinata NFT metadata)
+       Output: reads ticket mint ID from metadata or undefined
+    */
+     const attr_key = 'mintId'
+     let attr = ticket.metadata.keyvalues.hasOwnProperty(attr_key) ? ticket.metadata.keyvalues[attr_key] : undefined
+     return typeof attr != 'undefined' ? attr : "Attribute Not Set"
+  };
+  export function readUserID (ticket: PNFT) {
+    /* Input: Takes in a ticket (pinata NFT metadata)
+       Output: reads ticket user ID from metadata or undefined
+    */
+     const attr_key = 'user_id'
+     let attr = ticket.hasOwnProperty(attr_key) ? ticket[attr_key] : undefined
+     return typeof attr != 'undefined' ? attr : "Attribute Not Set"
+  };
+  export function readDatePinned (ticket: PNFT) {
+    /* Input: Takes in a ticket (pinata NFT metadata)
+       Output: reads ticket date pinned to pinata from metadata or undefined
+    */
+     const attr_key = 'date_pinned'
+     let attr = ticket.hasOwnProperty(attr_key) ? ticket[attr_key] : undefined
+     return typeof attr != 'undefined' ? attr : "Attribute Not Set"
+  };


### PR DESCRIPTION
adjustment to move pinata ticket read functions to separate .ts file ---> for deduplication & reusability across discord bot & app